### PR TITLE
Missing template.js in component.php of Protostar

### DIFF
--- a/templates/protostar/component.php
+++ b/templates/protostar/component.php
@@ -19,6 +19,9 @@ $this->setHtml5(true);
 // Add JavaScript Frameworks
 JHtml::_('bootstrap.framework');
 
+// Add template js
+JHtml::_('script', 'template.js', array('version' => 'auto', 'relative' => true));
+
 // Add html5 shiv
 JHtml::_('script', 'jui/html5.js', array('version' => 'auto', 'relative' => true, 'conditional' => 'lt IE 9'));
 


### PR DESCRIPTION
When showing forms in modals (for instance), radio buttons are not skinned and are actually partially hidden (because CSS from template.css hides the clickable buttons, only showing the labels).
This is the result of the missing template.js, which adds the proper class names to the form elements.

Pull Request for Issue # .

### Summary of Changes

Added the loading of template.js

### Testing Instructions

Create a contact mail custom field of radio type.
Create a menu item of type 'List contacts in a category'.
Create an override of the com_contacts component (category view).
Modify the link to the contact items in the default_items.php override to force the modals (just for test purposes):
JRoute::_(ContactHelperRoute::getContactRoute($item->slug, $item->catid)).'&tmpl=component'
In the frontend, this will open the contacts into component.php rather than index.php.

### Expected result

![after_fix](https://user-images.githubusercontent.com/5964177/55764443-85723180-5a39-11e9-8ce4-430b3348c83e.jpg)

### Actual result

![before_fix](https://user-images.githubusercontent.com/5964177/55764451-8c00a900-5a39-11e9-9dc1-ad07b4e87b2b.jpg)
