### PR TITLE
Add async capabilities js

### DIFF
--- a/administrator/modules/mod_healthcheck/tmpl/default.php
+++ b/administrator/modules/mod_healthcheck/tmpl/default.php
@@ -18,10 +18,12 @@ use Joomla\CMS\Layout\LayoutHelper;
 $wa = $app->getDocument()->getWebAssetManager();
 $wa->useScript('core')
     ->useScript('bootstrap.dropdown');
-$wa->registerAndUseScript('mod_quickicon', 'mod_quickicon/quickicon.min.js', ['relative' => true, 'version' => 'auto'], ['type' => 'module']);
 
-// Register and use the filter assets
+// Register and use the filter and async assets. The async script fills any quick-icon carrying a
+// data-url from com_ajax; mod_quickicon's script is intentionally not used here as it expects a
+// different response shape and would render "undefined" for these icons.
 $wa->registerAndUseScript('mod_healthcheck.filter', 'mod_healthcheck/healthcheck-filter.js', [], ['defer' => true])
+    ->registerAndUseScript('mod_healthcheck.async', 'mod_healthcheck/healthcheck-async.js', [], ['defer' => true])
     ->registerAndUseStyle('mod_healthcheck.general', 'mod_healthcheck/healthcheck.css');
 
 $gauges_html  = HTMLHelper::_('healthchecks.gauges', $gauges);

--- a/media_source/mod_healthcheck/js/healthcheck-async.es6.js
+++ b/media_source/mod_healthcheck/js/healthcheck-async.es6.js
@@ -1,0 +1,72 @@
+/**
+ * @copyright   (C) 2026 Open Source Matters, Inc. <https://www.joomla.org>
+ * @license     GNU General Public License version 2 or later; see LICENSE.txt
+ *
+ * Fills any Health Check quick-icon that carries a data-url by fetching its value from
+ * com_ajax, so heavy checks can be loaded after the dashboard has rendered.
+ */
+((document) => {
+  'use strict';
+
+  const STATUS_CLASS = {
+    success: 'success', warning: 'warning', error: 'danger', critical: 'danger', info: 'info',
+  };
+  const STATUS_FILTER = {
+    success: 'healthy', warning: 'warning', error: 'critical', critical: 'critical', info: 'healthy',
+  };
+
+  const fillIcon = async (amountEl) => {
+    const url = amountEl.getAttribute('data-url');
+
+    if (!url) {
+      return;
+    }
+
+    // Remove the attribute first so the icon is never fetched twice.
+    amountEl.removeAttribute('data-url');
+
+    try {
+      const response = await fetch(url, {
+        method: 'GET',
+        credentials: 'same-origin',
+        headers: { 'X-Requested-With': 'XMLHttpRequest' },
+      });
+      const json = await response.json();
+      const payload = json && json.data ? json.data : null;
+      const data = Array.isArray(payload) ? payload[0] : payload;
+
+      if (!data || typeof data.amount === 'undefined') {
+        amountEl.innerHTML = '<div>0</div>';
+        return;
+      }
+
+      amountEl.innerHTML = `<div>${parseInt(data.amount, 10) || 0}</div>`;
+
+      const status = data.status || 'success';
+      const link = amountEl.closest('a');
+
+      if (link) {
+        ['info', 'success', 'warning', 'danger'].forEach((c) => link.classList.remove(c));
+        link.classList.add(STATUS_CLASS[status] || 'info');
+      }
+
+      const wrapper = amountEl.closest('[data-healthcheck-status]');
+
+      if (wrapper) {
+        wrapper.setAttribute('data-healthcheck-status', STATUS_FILTER[status] || 'healthy');
+      }
+    } catch (e) {
+      amountEl.innerHTML = '<div>!</div>';
+    }
+  };
+
+  const init = () => {
+    document.querySelectorAll('.health-checks [data-url]').forEach(fillIcon);
+  };
+
+  if (document.readyState === 'loading') {
+    document.addEventListener('DOMContentLoaded', init);
+  } else {
+    init();
+  }
+})(document);


### PR DESCRIPTION
[x] I read the [Generative AI policy](https://developer.joomla.org/generative-ai-policy.html) and my contribution is either not created with the help of AI or is compatible with the policy and GNU/GPL 2 or later.

Nice work on this! I had a go at finishing the async loading that the icon layout already scaffolds — layouts/joomla/healthchecks/icon.php renders ajaxurl → data-url plus a spinner, but nothing was consuming the data-url yet, so any icon using it just sat on the spinner.

I put together a small follow-up that completes it: MacJoom:feature/mod_healthcheck-async (https://github.com/MacJoom/joomla-cms/tree/feature/mod_healthcheck-async) (commit 2146c49a94, branched right off this PR's head so it's a single commit on top).

What it does (2 files, mod_healthcheck only):

1. New media_source/mod_healthcheck/js/healthcheck-async.es6.js — generic, not tied to any one plugin. It finds every .health-checks [data-url] quick-icon, fetches its com_ajax URL, writes the count into .quickicon-amount, and sets the status class/data-healthcheck-status so the colour and the filter buttons stay correct. So any healthcheck plugin can now defer an expensive check by returning an ajaxurl instead of an amount.
2. tmpl/default.php — registers the new script, and drops the mod_quickicon.min.js registration. That core script also auto-grabs every [data-url] quick-icon, but nt (a single object) whereas a com_ajaxplugin response wraps results in an array — so it was writing literal undefined into the counter (and its response.data > 0 check always resolves to green). The dedicated script handles the com_ajax shape and the status colour correctly.
No layout changes needed — your icon.php ajaxurl/spinner markup is exactly what this consumes. media/ is gitignoreonly the .es6.js source is in the commit; npheck produces the compiled JS.

I've been driving it with a healthcheck-group plugin that offloads some filesystem-heavy checks this way, and the dashboard now renders instantly with the heappy to squash it into this PR or send ithowever suits you — let me know.


### Summary of Changes

added:
media_source/mod_healthcheck/js/healthcheck-async.es6.js
changed:
tmpl/default.php

### Testing Instructions

Test icons

### Actual result BEFORE applying this Pull Request

Icons work

### Expected result AFTER applying this Pull Request

Icons work (no async operations yet)

### Link to documentations
Please select:
- [ ] Documentation link for guide.joomla.org: <link>
- [x] No documentation changes for guide.joomla.org needed

- [ ] Pull Request link for manual.joomla.org: <link>
- [x] No documentation changes for manual.joomla.org needed
